### PR TITLE
Update the plugin to Jackson2 API Plugin 2.8.10.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Builds a module using https://github.com/jenkins-infra/pipeline-library
+buildPlugin()

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2015-2017 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Jackson Databind Plugin
+----
+
+:exclamation: The plugin is deprecated, 
+use [jackson2-api](https://github.com/jenkinsci/jackson2-api-plugin) instead.
+
 Deprecated plugin to pull in dependency on the Jackson parser data binding library (for JSON etc).
 
-Preference is to replace with a direct dependency on [jackson2-api](https://github.com/jenkinsci/jackson2-api-plugin)
+See the [Plugin Wiki Page](https://wiki.jenkins.io/display/JENKINS/Jackson+Databind+Plugin) for more info.

--- a/pom.xml
+++ b/pom.xml
@@ -5,53 +5,56 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.8.10.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Jackson Databind Plugin</name>
-    <description>Plugin to pull in dependency on the Jackson parser data binding library (for JSON etc).</description>
-    
+    <description>Deprecated. Plugin to pull in dependency on the Jackson parser data binding library (for JSON etc).</description>
+    <url>https://wiki.jenkins.io/display/JENKINS/Jackson+Databind+Plugin</url>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.5.5</version>
+            <version>2.8.10.1</version>
         </dependency>
     </dependencies>
-    
+
     <licenses>
         <license>
             <name>MIT License</name>
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
+
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>HEAD</tag>
     </scm>
- 
+
     <properties>
-      <java.level>6</java.level>
-      <jenkins.version>1.580.1</jenkins.version>
+      <!-- Requirements are similar to jackson2-api -->
+      <java.level>8</java.level>
+      <jenkins.version>2.60</jenkins.version>
     </properties>
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/jacksondatabind/JSONReadWrite.java
+++ b/src/main/java/org/jenkinsci/plugins/jacksondatabind/JSONReadWrite.java
@@ -25,6 +25,9 @@ package org.jenkinsci.plugins.jacksondatabind;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import hudson.RestrictedSince;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +39,12 @@ import java.nio.charset.Charset;
 /**
  * JSON read/write utilities.
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ * @deprecated The plugin is deprecated. All code should be migrated to
+ *             <a href="https://github.com/jenkinsci/jackson2-api-plugin">Jackson2 API Plugin</a>.
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
+@RestrictedSince("2.8.10.1")
 public class JSONReadWrite {
 
     static final Charset UTF8 = Charset.forName("UTF-8");

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Plugin to pull in dependency on the Jackson parser data binding library (for JSON etc).
+    <b>Deprecated</b>. Plugin to pull in dependency on the Jackson parser data binding library (for JSON etc).
 </div>


### PR DESCRIPTION
The change also does the license/POM cleanup. 
It effectively expands https://github.com/jenkinsci/jackson-databind-plugin/pull/1 from @stephenc and makes the plugin's EoL more explicit.

@reviewbybees @stephenc @ndeloof 
